### PR TITLE
Fixes broken link to 2012 report

### DIFF
--- a/_posts/2013-01-11-thanks.html
+++ b/_posts/2013-01-11-thanks.html
@@ -10,5 +10,5 @@ pagetype: quote
 	<img src="img/flag_tag.png" alt="Code for America flag tag" />
 </div>
 <div class="attribution">
-	<p>Original design <a href="http://www.2012.codeforamerica.org" target="_blank">created in 2012</a> by: Angel Kittyachavalit, Mick Thompson&nbsp;&nbsp;&nbsp;&nbsp; | &nbsp;&nbsp;&nbsp;&nbsp;This report created with help from: &nbsp;&nbsp;&nbsp;&nbsp;<a href="http://www.postcode.io" target="_blank"><img src="img/postcode_logo.png"></a></p>
+	<p>Original design <a href="http://2012.codeforamerica.org" target="_blank">created in 2012</a> by: Angel Kittyachavalit, Mick Thompson&nbsp;&nbsp;&nbsp;&nbsp; | &nbsp;&nbsp;&nbsp;&nbsp;This report created with help from: &nbsp;&nbsp;&nbsp;&nbsp;<a href="http://www.postcode.io" target="_blank"><img src="img/postcode_logo.png"></a></p>
 </div>


### PR DESCRIPTION
The link to the 2012 report was broken, this scratches the `www.`.
