### PR TITLE
Added missing space to Oakland public records story.

### DIFF
--- a/_posts/2013-02-03-story2.html
+++ b/_posts/2013-02-03-story2.html
@@ -45,7 +45,7 @@ image:
             </div>
             <br><br>
               <p>The City of Oakland receives a huge volume of public records requests. Although City staff 
-              strove to respond quickly,their existing system made it difficult to track outstanding inquiries and often created duplicate work. The tool and the process was frustrating for both residents and staff. As a result, tensions arose between the community and the City over request compliance.</p><br>
+              strove to respond quickly, their existing system made it difficult to track outstanding inquiries and often created duplicate work. The tool and the process was frustrating for both residents and staff. As a result, tensions arose between the community and the City over request compliance.</p><br>
               <p>The 2013 Fellows built RecordTrac to streamline this
               process &mdash; for residents and city employees. The tool offers three key services: a searchable archive of past requests and responses, a simple form to make new requests, and updates about the status of a request. More than 2,000 requests were submitted through RecordTrac by year's end.
               </p><br>


### PR DESCRIPTION
Added missing space to Oakland public records story. 'quickly,their' --> 'quickly, their'